### PR TITLE
Support for battery level

### DIFF
--- a/Switchmate3Manager.js
+++ b/Switchmate3Manager.js
@@ -55,6 +55,7 @@ var Switchmate3Manager = function ()
                 {
                     manager.Switchmate3s[smid].ToggleState = foundSm.ToggleState;
                     manager.event.emit('smToggleStateChange', smid, foundSm.ToggleState);
+                    manager.event.emit('smBatteryLevelChange', smid, foundSm.BatteryLevel);
                 }
                 manager.Switchmate3s[smid].foundMe();
             }
@@ -74,6 +75,18 @@ Switchmate3Manager.prototype.Initialize = function (sm_config)
         }
         manager.FindAllSwitchmate3s();
         manager.initialized = true;
+    }
+};
+
+Switchmate3Manager.prototype.GetSwitchmate3BatteryLevel = function (smid)
+{
+    manager = this;
+    if (typeof manager.Switchmate3s[smid] !== 'undefined')
+    {
+        return manager.Switchmate3s[smid].BatteryLevel || 100; //if Switchmate3 exists, return its last known Battery Level.
+    } else
+    {
+        return 100;  //otherwise, just assume it is 100%.
     }
 };
 
@@ -107,7 +120,9 @@ Switchmate3Manager.prototype.On = function (smid)
         (manager.Switchmate3s[smid].ToggleState === false || manager.Switchmate3s[smid].ToggleState === null))
     {
         var ToggleMode = manager.Switchmate3s[smid].ToggleMode();
-        //ToggleMode.event.on('toggleDone', restartScan);
+        ToggleMode.event.once('toggleDone', function() {
+            manager.event.emit('smBatteryLevelChange', smid, manager.Switchmate3s[smid].BatteryLevel);
+        });
         ToggleMode.TurnOn();
     }
 };
@@ -119,6 +134,9 @@ Switchmate3Manager.prototype.Off = function (smid)
         manager.Switchmate3s[smid].ToggleState === true || manager.Switchmate3s[smid].ToggleState === null))
     {
         var ToggleMode = manager.Switchmate3s[smid].ToggleMode();
+        ToggleMode.event.once('toggleDone', function() {
+            manager.event.emit('smBatteryLevelChange', smid, manager.Switchmate3s[smid].BatteryLevel);
+        });
         ToggleMode.TurnOff();
     }
 };

--- a/config-sample-linux.json
+++ b/config-sample-linux.json
@@ -6,7 +6,8 @@
                 {
                     "displayName": "Porch Light",
                     "id": "fe5c32ba4c95",
-                    "model": "TSM003W"
+                    "model": "TSM003W",
+                    "lowBatteryPercent": 25
                 }
             ]
         }

--- a/config-sample-macos.json
+++ b/config-sample-macos.json
@@ -6,7 +6,8 @@
                 {
                     "displayName": "Porch Light",
                     "id": "754ffdf6021c4285b7240c0a778ebd96",
-                    "model": "TSM003W"
+                    "model": "TSM003W",
+                    "lowBatteryPercent": 25
                 }
             ]
         }

--- a/index.js
+++ b/index.js
@@ -141,6 +141,8 @@ Switchmate3Platform.prototype.getInitState = function (accessory, data) {
     accessory.context.model = data.model || "";
     info.setCharacteristic(Characteristic.Model, accessory.context.model);
 
+    accessory.context.lowBatteryPercent = data.lowBatteryPercent || 25;
+
     info.setCharacteristic(Characteristic.SerialNumber, accessory.context.id);
 
     accessory.getService(Service.Switch)
@@ -186,6 +188,6 @@ Switchmate3Platform.prototype.getBatteryLevel = function (mySwitchmate3, callbac
 
 Switchmate3Platform.prototype.getBatteryIsLow = function (mySwitchmate3, callback) {
     var platform = this;
-    var isLowBattery = platform.SmManager.GetSwitchmate3BatteryLevel(mySwitchmate3.id) < 25;
+    var isLowBattery = platform.SmManager.GetSwitchmate3BatteryLevel(mySwitchmate3.id) <= parseInt(mySwitchmate3.lowBatteryPercent);
     callback(null, isLowBattery);
 };


### PR DESCRIPTION
This exposes the Switchmate's battery level to HomeKit and also triggers a low battery warning if the battery level is below 25%.

Support for reading the battery level requires https://github.com/valkjsaaa/node-switchmate3/pull/4 to be merged and a new version of the library released.

The battery level enhancements in node-switchmate3 will only update the battery level after a toggle, so HomeKit will assume the battery level is 100% until a toggle action is completed.